### PR TITLE
jest --watch from a docker container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .idea
+yarn.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,0 @@
-FROM node:8.5.0
-
-ADD . . 
-
-RUN npm install

--- a/README.md
+++ b/README.md
@@ -23,3 +23,27 @@ Aby puścić pojedynczy test, możesz wykonać:
 ```
 npm test -- problem1
 ```
+
+### Jeśli masz Dockera (i `docker-compose`)
+
+Wystartuj kontener za pomocą `docker-compose`:
+
+```
+docker-compose up -d
+```
+
+Następnie możesz wejść do kontenera za pomocą komendy:
+
+```
+docker-compose exec node sh
+```
+
+Teraz po wpisaniu komendy `ls` powinieneś zobaczyć pliki, które znajdują się w repo - np. folder `node_modules`.
+
+Od teraz możesz posługiwać się konsolą tak, jakbyś miał zainstalowanego Node.js (patrz wyżej).
+
+Po zakończeniu pracy puść następującą komendę, aby wyłączyć kontener:
+
+```
+docker-compose down
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,4 +6,5 @@ services:
     working_dir: /promises
     volumes:
       - ./:/promises
-    command: "npm run test:watch"
+    stdin_open: true
+    tty: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "2"
+services:
+  node:
+    image: "node:9"
+    user: "node"
+    working_dir: /promises
+    volumes:
+      - ./:/promises
+    command: "npm run test:watch"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "jest"
+    "test": "jest --verbose",
+    "test:watch": "jest --watch --verbose"
   },
   "author": "Mateusz Podlasin",
   "license": "ISC",


### PR DESCRIPTION
That's the closest to 'push a button and it works' I could get, but it doesn't allow to trigger any actions. I've considered adding a couple of `npm` scripts that would allow to a) setup the `docker-compose` solutions or b) log into a container to execute commands there, but I don't know if having scripts dependent on user's system setup (having Docker in this instance) is a good idea... What do you thing?